### PR TITLE
Refactor `http.Authorize` to take `permissionsGetter`

### DIFF
--- a/model/email_test.go
+++ b/model/email_test.go
@@ -3,8 +3,9 @@ package model_test
 import (
 	"testing"
 
-	"maragu.dev/glue/model"
 	"maragu.dev/is"
+
+	"maragu.dev/glue/model"
 )
 
 func TestEmailAddress_IsValid(t *testing.T) {


### PR DESCRIPTION
Because that one is needed anyway for permissions, and then the client doesn't need two implementations.