### PR TITLE
Add emails templates for changing user emails

### DIFF
--- a/email/emails/new-email-confirmation.html
+++ b/email/emails/new-email-confirmation.html
@@ -1,0 +1,12 @@
+<h1>Hi {{name}}!</h1>
+
+<p>
+  Your email address for log in at <a href="{{baseURL}}">{{appName}}</a> is
+  being changed from {{oldEmail}} to {{newEmail}}.
+</p>
+
+<p>
+  <a href="{{baseURL}}/profile/email?token={{token}}">Click here to confirm</a>.
+</p>
+
+<p>If you do not want this, you can simply ignore this email.</p>

--- a/email/emails/new-email-notification.html
+++ b/email/emails/new-email-notification.html
@@ -1,0 +1,8 @@
+<h1>Hi {{name}}!</h1>
+
+<p>
+  Your email address for log in at <a href="{{baseURL}}">{{appName}}</a> is
+  being changed from {{oldEmail}} to {{newEmail}}.
+</p>
+
+<p>If this is not what you want, please reply to this email immediately!</p>


### PR DESCRIPTION
Also, HTML escape keywords in the emails (!), and set app name and recipient name as default keywords.