### PR TITLE
Replace `WithSkipMigrations` with `WithMigrationFunc` in `sqlitetest`

### DIFF
--- a/sqlitetest/helper.go
+++ b/sqlitetest/helper.go
@@ -16,7 +16,7 @@ import (
 // NewHelper for testing, with optional options.
 // Options:
 // - [WithFixtures] to load fixtures after migration.
-// - [WithSkipMigrations] to skip running database migrations.
+// - [WithMigrationFunc] to use a custom migration function instead of the built-in one.
 func NewHelper(t *testing.T, opts ...HelperOption) *sql.Helper {
 	t.Helper()
 
@@ -41,10 +41,12 @@ func NewHelper(t *testing.T, opts ...HelperOption) *sql.Helper {
 		t.Fatal(err)
 	}
 
-	if !config.skipMigrations {
-		if err := h.MigrateUp(t.Context()); err != nil {
-			t.Fatal(err)
-		}
+	if config.migrationFunc == nil {
+		config.migrationFunc = h.MigrateUp
+	}
+
+	if err := config.migrationFunc(t.Context()); err != nil {
+		t.Fatal(err)
 	}
 
 	if len(config.fixtures) > 0 {

--- a/sqlitetest/options.go
+++ b/sqlitetest/options.go
@@ -1,6 +1,7 @@
 package sqlitetest
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,8 +14,8 @@ type HelperOption func(*helperConfig)
 
 // helperConfig used with [HelperOption].
 type helperConfig struct {
-	fixtures       []string
-	skipMigrations bool
+	fixtures      []string
+	migrationFunc func(context.Context) error
 }
 
 // WithFixtures adds SQL fixtures to be run after migrations.
@@ -27,10 +28,10 @@ func WithFixtures(fixtures ...string) HelperOption {
 	}
 }
 
-// WithSkipMigrations skips running database migrations.
-func WithSkipMigrations() HelperOption {
+// WithMigrationFunc sets a custom migration function to run instead of the built-in one.
+func WithMigrationFunc(fn func(context.Context) error) HelperOption {
 	return func(c *helperConfig) {
-		c.skipMigrations = true
+		c.migrationFunc = fn
 	}
 }
 


### PR DESCRIPTION
- Add `WithMigrationFunc` option that accepts custom migration function
- Remove `WithSkipMigrations` option and `skipMigrations` field
- Update helper logic to use custom migration function or default to `h.MigrateUp`
- Update tests to cover new `WithMigrationFunc` functionality
- Remove tests for the deprecated `WithSkipMigrations` option